### PR TITLE
Improved nixos module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,8 +79,6 @@
               install_binary kwybarsctl
 
               install -Dm644 assets/examples/config.toml "$out/share/kwybars/examples/config.toml"
-              install -Dm644 assets/systemd/kwybars-daemon.service \
-                "$out/lib/systemd/user/kwybars-daemon.service"
               install -Dm644 assets/themes/*.toml -t "$out/share/kwybars/themes"
 
               wrapProgram "$out/bin/kwybars-daemon" \

--- a/flake.nix
+++ b/flake.nix
@@ -128,9 +128,21 @@
         let
           cfg = config.programs.kwybars;
           package = cfg.package;
-          configArg = lib.optionalString (
-            cfg.configPath != null
-          ) " --config ${lib.escapeShellArg (toString cfg.configPath)}";
+
+          resolvedPath =
+            if cfg.settings != { } then
+              (pkgs.formats.toml { }).generate "kwybars.toml" cfg.settings
+
+            else if cfg.preset != null then
+              "${package}/share/kwybars/examples/${cfg.preset}.toml"
+            else
+              cfg.configPath; # may be null → no --config flag
+
+          activeSources = lib.count lib.id [
+            (cfg.settings != { })
+            (cfg.configPath != null)
+            (cfg.preset != null)
+          ];
         in
         {
           options.programs.kwybars = {
@@ -143,6 +155,23 @@
               description = "Kwybars package to install.";
             };
 
+            settings = lib.mkOption {
+              type = lib.types.nullOr (pkgs.formats.toml { }).type;
+              default = { };
+              example = lib.literalExpression ''
+                {
+                	overlay.position 	= "bottom"
+                	overlay.width 		= 800
+                	overlay.height 		= 500
+                }
+              '';
+              description = ''
+                Kwybars configuration as a Nix attribute set, serialised to TOML
+                and passed via --config. Mutually exclusive with
+                <option>configPath</option> and <option>preset</option>.
+              '';
+            };
+
             configPath = lib.mkOption {
               type = lib.types.nullOr (
                 lib.types.oneOf [
@@ -152,7 +181,32 @@
               );
               default = null;
               example = lib.literalExpression ''"/home/alice/.config/kwybars/current.toml"'';
-              description = "Optional config path passed to the packaged user service.";
+              description = ''
+                Path to an existing TOML config file passed via --config.
+                Mutually exclusive with <option>settings</option> and
+                <option>preset</option>.
+              '';
+            };
+
+            preset = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              example = lib.literalExpression ''"config"'';
+              description = ''
+                Name of a bundled example config (without the .toml extension)
+                shipped under <literal>''${package}/share/kwybars/examples/</literal>.
+                For example, <literal>"config"</literal> resolves to
+                <literal>''${package}/share/kwybars/examples/config.toml</literal>.
+                Mutually exclusive with <option>settings</option> and
+                <option>configPath</option>.
+              '';
+            };
+
+            extraArgs = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              example = [ "--verbose" ];
+              description = "Extra command-line arguments to pass to the kwybars-daemon executable.";
             };
 
             systemd.enable = lib.mkOption {
@@ -163,6 +217,24 @@
           };
 
           config = lib.mkIf cfg.enable {
+            assertions = [
+              {
+                assertion = activeSources <= 1;
+                message = ''
+                  programs.kwybars: at most one of `settings`, `configPath`, or `preset`
+                  may be set at a time (${toString activeSources} are currently set).
+                '';
+              }
+              {
+                assertion =
+                  cfg.preset == null || builtins.pathExists "${package}/share/kwybars/examples/${cfg.preset}.toml";
+                message = ''
+                  programs.kwybars.preset: "${cfg.preset}.toml" was not found in
+                  ${package}/share/kwybars/examples/.
+                '';
+              }
+            ];
+
             environment.systemPackages = [ package ];
 
             systemd.user.services.kwybars-daemon = lib.mkIf cfg.systemd.enable {
@@ -171,9 +243,13 @@
               partOf = [ "graphical-session.target" ];
               wantedBy = [ "default.target" ];
 
+              environment = lib.mkIf (resolvedPath != null) {
+                KWYBARS_CONFIG = toString resolvedPath;
+              };
+
               serviceConfig = {
                 Type = "simple";
-                ExecStart = "${package}/bin/kwybars-daemon${configArg}";
+                ExecStart = "${package}/bin/kwybars-daemon ${lib.escapeShellArgs cfg.extraArgs}";
                 Restart = "on-failure";
                 RestartSec = 2;
               };

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,7 @@
               install_binary kwybars-overlay
               install_binary kwybarsctl
 
-              install -Dm644 assets/examples/config.toml "$out/share/kwybars/examples/config.toml"
+              install -Dm644 assets/examples/*.toml -t "$out/share/kwybars/examples"
               install -Dm644 assets/themes/*.toml -t "$out/share/kwybars/themes"
 
               wrapProgram "$out/bin/kwybars-daemon" \

--- a/flake.nix
+++ b/flake.nix
@@ -20,8 +20,7 @@
         system:
         let
           pkgs = pkgsFor system;
-          workspaceVersion =
-            (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
+          workspaceVersion = (fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
         in
         rec {
           kwybars = pkgs.rustPlatform.buildRustPackage {
@@ -77,11 +76,21 @@
 
               wrapProgram "$out/bin/kwybars-daemon" \
                 --set KWYBARS_THEMES_DIR "$out/share/kwybars/themes" \
-                --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.cava pkgs.libnotify ]}:$out/bin
+                --prefix PATH : ${
+                  pkgs.lib.makeBinPath [
+                    pkgs.cava
+                    pkgs.libnotify
+                  ]
+                }:$out/bin
 
               wrapProgram "$out/bin/kwybars-overlay" \
                 --set KWYBARS_THEMES_DIR "$out/share/kwybars/themes" \
-                --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.cava pkgs.libnotify ]}:$out/bin
+                --prefix PATH : ${
+                  pkgs.lib.makeBinPath [
+                    pkgs.cava
+                    pkgs.libnotify
+                  ]
+                }:$out/bin
 
               wrapProgram "$out/bin/kwybarsctl" \
                 --set KWYBARS_THEMES_DIR "$out/share/kwybars/themes"
@@ -122,18 +131,20 @@
 
             package = lib.mkOption {
               type = lib.types.package;
-              default = self.packages.${pkgs.system}.default;
-              defaultText = lib.literalExpression "inputs.kwybars.packages.${pkgs.system}.default";
+              default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+              defaultText = lib.literalExpression "inputs.kwybars.packages.${pkgs.stdenv.hostPlatform.system}.default";
               description = "Kwybars package to install.";
             };
 
             configPath = lib.mkOption {
-              type = lib.types.nullOr (lib.types.oneOf [
-                lib.types.path
-                lib.types.str
-              ]);
+              type = lib.types.nullOr (
+                lib.types.oneOf [
+                  lib.types.path
+                  lib.types.str
+                ]
+              );
               default = null;
-              example = lib.literalExpression "\"/home/alice/.config/kwybars/current.toml\"";
+              example = lib.literalExpression ''"/home/alice/.config/kwybars/current.toml"'';
               description = "Optional config path passed to the packaged user service.";
             };
 
@@ -162,6 +173,14 @@
             };
           };
         };
+
+      formatter = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        pkgs.nixfmt
+      );
 
       apps = forAllSystems (
         system:

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,16 @@
             pname = "kwybars";
             version = workspaceVersion;
 
-            src = self;
+            src = pkgs.lib.fileset.toSource {
+              root = ./.;
+              fileset = pkgs.lib.fileset.unions [
+                ./Cargo.toml
+                ./Cargo.lock
+                ./assets/examples
+                ./assets/themes
+                ./crates
+              ];
+            };
 
             cargoLock = {
               lockFile = ./Cargo.lock;

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,6 @@
-{ pkgs ? import <nixpkgs> {} }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
 pkgs.mkShell {
   buildInputs = with pkgs; [
@@ -12,7 +14,7 @@ pkgs.mkShell {
     gtk4-layer-shell
     pipewire
     cava
-    libnotify  # optional: desktop error notifications
+    libnotify # optional: desktop error notifications
 
     # pkg-config so cargo's build scripts can find libraries
     pkg-config


### PR DESCRIPTION
- `settings` option to generate configuration.toml from nix
- `preset` option to load example configurations bundled  with the nix derivation
- Replacing `configArg` with `extraArgs` + `KWYBARS_CONFIG` environment
  variable.

Now the user can:
- pass any flag to the systemd service via `extraArgs`.
- configure the config.toml via nix, via path, or use a preset from the examples folder

> I also did some chores in the `.nix` files 

Thank you for the cool project