### PR TITLE
Copied all preset configuraton from documentation

### DIFF
--- a/assets/examples/floating.toml
+++ b/assets/examples/floating.toml
@@ -1,0 +1,16 @@
+[overlay]
+monitor_mode = "primary"
+layer = "background"
+position = "bottom"
+full_length = true
+height = 260
+
+[visualizer]
+layout = "floating"
+bars = 16
+bar_width = 50
+gap = 14
+framerate = 60
+color_mode = "gradient"
+color_rgba = "rgba(251, 191, 36, 0.8)"
+color2_rgba = "rgba(244, 114, 182, 0.8)"

--- a/assets/examples/frame.toml
+++ b/assets/examples/frame.toml
@@ -1,0 +1,22 @@
+[overlay]
+monitor_mode = "primary"
+layer = "background"
+full_length = true
+height = 340
+anchor_margin = 18
+margin_left = 18
+margin_right = 18
+margin_top = 0
+margin_bottom = 0
+
+[visualizer]
+layout = "frame"
+frame_edges = ["top", "bottom"]
+bars = 88
+bar_width = 8
+gap = 10
+framerate = 60
+bar_corner_radius = 16
+color_mode = "gradient"
+color_rgba = "rgba(244, 184, 228, 0.8)"
+color2_rgba = "rgba(180, 190, 254, 0.8)"

--- a/assets/examples/line.toml
+++ b/assets/examples/line.toml
@@ -1,0 +1,21 @@
+[overlay]
+monitor_mode = "primary"
+layer = "background"
+position = "bottom"
+full_length = true
+height = 480
+anchor_margin = 20
+margin_left = 20
+margin_right = 20
+
+[visualizer]
+layout = "line"
+line_mode = "continuous"
+bars = 44
+bar_width = 20
+gap = 14
+framerate = 60
+bar_corner_radius = 18
+color_mode = "gradient"
+color_rgba = "rgba(175, 198, 255, 0.78)"
+color2_rgba = "rgba(191, 198, 220, 0.78)"

--- a/assets/examples/mirror.toml
+++ b/assets/examples/mirror.toml
@@ -1,0 +1,21 @@
+[overlay]
+monitor_mode = "primary"
+layer = "background"
+full_length = true
+height = 860
+anchor_margin = 20
+margin_left = 20
+margin_right = 20
+
+[visualizer]
+layout = "mirror"
+mirror_orientation = "horizontal"
+bars = 72
+bar_width = 13
+gap = 12
+mirror_gap = 30
+framerate = 60
+bar_corner_radius = 18
+color_mode = "gradient"
+color_rgba = "rgba(166, 227, 161, 0.82)"
+color2_rgba = "rgba(137, 180, 250, 0.82)"

--- a/assets/examples/particle.toml
+++ b/assets/examples/particle.toml
@@ -1,0 +1,20 @@
+[overlay]
+monitor_mode = "primary"
+layer = "background"
+position = "bottom"
+full_length = true
+height = 300
+anchor_margin = 0
+margin_left = 0
+margin_right = 0
+margin_bottom = 0
+
+[visualizer]
+layout = "particle"
+bars = 10
+bar_width = 100
+gap = 14
+framerate = 60
+color_mode = "gradient"
+color_rgba = "rgba(147, 197, 253, 0.82)"
+color2_rgba = "rgba(134, 239, 172, 0.82)"

--- a/assets/examples/polygon.toml
+++ b/assets/examples/polygon.toml
@@ -1,0 +1,21 @@
+[overlay]
+monitor_mode = "primary"
+layer = "background"
+
+[visualizer]
+layout = "polygon"
+bars = 44
+bar_width = 12
+gap = 8
+framerate = 60
+polygon_sides = 3
+polygon_radius = 280
+polygon_rotation = -90
+polygon_rotation_speed = 0
+polygon_bar_length = 360
+center_offset_x = 0
+center_offset_y = 20
+bar_corner_radius = 16
+color_mode = "gradient"
+color_rgba = "rgba(248, 189, 150, 0.85)"
+color2_rgba = "rgba(202, 158, 230, 0.85)"

--- a/assets/examples/radial.toml
+++ b/assets/examples/radial.toml
@@ -1,0 +1,22 @@
+[overlay]
+monitor_mode = "primary"
+layer = "background"
+width = 620
+height = 620
+
+[visualizer]
+layout = "radial"
+bars = 46
+bar_width = 10
+gap = 8
+framerate = 60
+radial_inner_radius = 164
+radial_arc_degrees = 360
+radial_start_angle = 0
+radial_rotation_speed = 0
+center_offset_x = 0
+center_offset_y = 0
+bar_corner_radius = 16
+color_mode = "gradient"
+color_rgba = "rgba(122, 162, 247, 0.88)"
+color2_rgba = "rgba(187, 154, 247, 0.88)"

--- a/assets/examples/wave.toml
+++ b/assets/examples/wave.toml
@@ -1,0 +1,24 @@
+[overlay]
+monitor_mode = "primary"
+layer = "background"
+position = "bottom"
+full_length = true
+height = 220
+anchor_margin = 0
+margin_left = 0
+margin_right = 0
+margin_bottom = 0
+
+[visualizer]
+layout = "wave"
+bars = 10
+framerate = 60
+wave_stroke_width = 6
+wave_fill = true
+wave_glow = false
+wave_smoothing = 1
+wave_motion_smoothing = 0.1
+wave_amplitude = 0.9
+color_mode = "gradient"
+color_rgba = "rgba(125, 207, 255, 0.78)"
+color2_rgba = "rgba(192, 132, 252, 0.78)"


### PR DESCRIPTION
I grabbed all the `config.toml` examples from `https://naurissteins.com/kwybars/docs/preset-configs/*` and placed them in the repo in the `assets/examples` folder.

Thanks to #12 this makes it possible to select them from the nixos module directly:
```nix
programs.kwybars.preset = "wave";
```
